### PR TITLE
Added Ability to Create Junit Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Running the following command will execute the test suite:
 
 Cucumber tasks can be configured at two levels, globally for the project and individually for a test suite. This allows
 for projects to contain multiple Cucumber test suites that can differ on some properties while inheriting other
-property values form the project defaults. BOth levels of configuration make the following settings available:
+property values form the project defaults. Both levels of configuration make the following settings available:
 
 * `stepDefinitionRoots`: A list of root packages to scan the classpath for glue code. Default to **['cucumber.steps', 'cucumber.hooks']**
 * `featureRoots`: A list of root packages to scan the resources folders on the classpath for feature files. Defaults to **['features']**
@@ -75,4 +75,9 @@ property values form the project defaults. BOth levels of configuration make the
 * `snippits`: Indicator to cucumber on what style to use for generated step examples. Legal values include camelcase, underscore. Defaults to **camelcase**
 * `maxParallelForks`: Maximum number of forked Java processes to start to run tests in parallel. Default to **1**
 
+### Reporting
+
+By default, this plugin will generate reports based on [masterthought's Cucumber reporting project](https://github.com/masterthought/cucumber-reporting). 
+
+Junit reporting can be enabled by setting the `junitReport` property to true. 
 

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberExtension.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberExtension.groovy
@@ -50,6 +50,11 @@ class CucumberExtension {
      */
     String snippets = 'camelcase'
 
+    /**
+     * Property to enable/disable junit reporting
+     */
+    boolean junitReport = false
+
     private final Project project
 
     CucumberExtension(Project project) {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
@@ -14,6 +14,8 @@ import java.nio.file.Paths
  */
 @Slf4j
 class CucumberRunner {
+    private static final String PLUGIN = '--plugin'
+
     CucumberRunnerOptions options
     CucumberTestResultCounter testResultCounter
 
@@ -35,14 +37,19 @@ class CucumberRunner {
                 File resultsFile = new File(resultsDir, "${featureName}.json")
                 File consoleOutLogFile = new File(resultsDir, "${featureName}-out.log")
                 File consoleErrLogFile = new File(resultsDir, "${featureName}-err.log")
+                File junitResultsFile = new File(resultsDir, "${featureName}.xml")
 
                 List<String> args = []
                 options.stepDefinitionRoots.each {
                     args << '--glue'
                     args << it
                 }
-                args << '--plugin'
+                args << PLUGIN
                 args << "json:${resultsFile.absolutePath}"
+                if (options.junitReport) {
+                    args << PLUGIN
+                    args << "junit:${junitResultsFile.absolutePath}"
+                }
                 if (options.isDryRun) {
                     args << '--dry-run'
                 }

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunnerOptions.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunnerOptions.groovy
@@ -20,4 +20,6 @@ interface CucumberRunnerOptions {
     String getSnippets()
 
     int getMaxParallelForks()
+
+    boolean getJunitReport()
 }

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -26,6 +26,7 @@ class CucumberTask extends DefaultTask implements CucumberRunnerOptions {
     Boolean isMonochrome = null
     Boolean isStrict = null
     String snippets = null
+    boolean junitReport = null
 
     @TaskAction
     void runTests() {
@@ -127,5 +128,9 @@ class CucumberTask extends DefaultTask implements CucumberRunnerOptions {
 
     String getSnippets() {
         return snippets ?: extension.snippets
+    }
+
+    boolean getJunitReport() {
+        return junitReport ?: extension.junitReport
     }
 }


### PR DESCRIPTION
The changes I made will allow the user to specify if they want the plugin to generate junit reports. This is controlled using the new junitReport property.