### PR TITLE
update to shorten URI paths in JSON file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,17 @@ dependencies {
 
     compile 'org.codehaus.gpars:gpars:1.2.1'
     compile 'org.zeroturnaround:zt-exec:1.8'
-    compile 'net.masterthought:cucumber-reporting:0.1.0'
+    compile 'net.masterthought:cucumber-reporting:0.6.0'
 
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     testCompile 'com.netflix.nebula:nebula-test:2.2.1'
+}
+
+sourceSets {
+    test {
+        //remove incompatible jar from test class path
+        runtimeClasspath = runtimeClasspath.minus files("$gradle.gradleHomeDir/lib/commons-io-1.4.jar")
+    }
 }
 
 codenarc {


### PR DESCRIPTION
•	Updated version of Masterthoughts plugin to version 0.6.0  (current)
•	Added logic to shorten lengthy source paths written in the uri of the Json files to relative paths to help overcome file path limitations imposed by Windows.  Initially Tried changing the ProcessExecutor to set directory to   processExecutor.directory(new File('.')), however this tool  resulted in absolute paths being written to json files.  Masterthoughts uses this path to construct unique file names for the report files, rendering long file names in an already long system path and ultimately exceeding Windows path\file length limitation.  This bandage put in place so we can move forward with continuous integration of cucumber test framework.
•	 
