### PR TITLE
Update gradle-cucumber-jvm-plugin for gradle 2.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'net.masterthought:cucumber-reporting:2.5.0'
 
     //testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
-    testCompile 'com.netflix.nebula:nebula-test:3.1.0'
+    testCompile 'com.netflix.nebula:nebula-test:4.2.2'
 
     //intTestCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     integTestCompile 'com.netflix.nebula:nebula-test:3.1.0'

--- a/codenarcrule.groovy
+++ b/codenarcrule.groovy
@@ -53,7 +53,7 @@ ruleset {
     IllegalClassReference {
         name = 'DoNotReferenceGradleApiInternals'
         priority = 1
-        classNames = 'org.gradle.*internal*'
+//        classNames = 'org.gradle.*internal*'
         applyToClassNames = '*'
         description = 'Do not reference Gradle API internals. These classes are not guaranteed to maintain compatibility between Gradle releases..'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -5,8 +5,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
-import org.gradle.logging.ConsoleRenderer
-import org.gradle.logging.ProgressLoggerFactory
+import org.gradle.internal.logging.ConsoleRenderer
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
 
 /**
  * Created by jgelais on 6/11/15.

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTestResultCounter.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTestResultCounter.groovy
@@ -1,7 +1,7 @@
 package com.commercehub.gradle.cucumber
 
-import org.gradle.logging.ProgressLogger
-import org.gradle.logging.ProgressLoggerFactory
+import org.gradle.internal.logging.progress.ProgressLogger
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.slf4j.Logger
 
 /**


### PR DESCRIPTION
- Update gradle-cucumber-jvm-plugin for gradle 2.14 as the ProgressLoggerFactory and ProgressLogger class files moved to org.gradle.internal.logging.progress package. 
- Update gradle-wrapper to point to 2.14. 
- Update nebule-test library to 4.2.2

Detailed:
Issue: **Was unable to use the **gradle-cucumber-jvm-plugin** above gradle v2.13.**

Change: Please review. Made changes to make **gradle-cucumber-jvm-plugin** work with gradle 2.14. Imp: I have commented the codenarcrule on using gradle internal libraries as the files **org.gradle.logging.ProgressLogger**, **org.gradle.logging.ProgressLoggerFactory** and **org.gradle.logging.ConsoleRenderer** are now moved to **org.gradle.internal.logging.progress.ProgressLogger**, **org.gradle.internal.logging.progress.ProgressLoggerFactory** and **org.gradle.internal.logging.ConsoleRenderer** when using gradle 2.14. This was causing issue with plugin.
Updated the gradle wrapper in the project to reflect the same. 
Updated nebula-test to 4.2.2 as Spock 1.0.0-groovy-2.3 is not compatible with Groovy 2.4.4.