### PR TITLE
Add ignoreFailures capability for use on Jenkins CI

### DIFF
--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberExtension.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberExtension.groovy
@@ -55,6 +55,11 @@ class CucumberExtension {
      */
     boolean junitReport = false
 
+    /**
+     * Property to cause or prevent build failure when cucumber tests fail
+     */
+    boolean ignoreFailures = false
+
     private final Project project
 
     CucumberExtension(Project project) {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -29,6 +29,7 @@ class CucumberTask extends DefaultTask implements CucumberRunnerOptions {
     String snippets = null
     Map<String, String> systemProperties = [:]
     boolean junitReport = null
+    Boolean ignoreFailures = null
 
     @TaskAction
     void runTests() {
@@ -85,7 +86,11 @@ class CucumberTask extends DefaultTask implements CucumberRunnerOptions {
         String reportUrl = new ConsoleRenderer().asClickableFileUrl(new File(reportsDir, 'feature-overview.html'))
         String message = "There were failing tests. See the report at: $reportUrl"
 
-        throw new GradleException(message)
+        if (ignoreFailures ?: extension.ignoreFailures) {
+            logger.warn(message)
+        } else {
+            throw new GradleException(message)
+        }
     }
 
     SourceSet getSourceSet() {
@@ -130,5 +135,9 @@ class CucumberTask extends DefaultTask implements CucumberRunnerOptions {
 
     boolean getJunitReport() {
         return junitReport ?: extension.junitReport
+    }
+
+    boolean getIgnoreFailures() {
+        return ignoreFailures ?: extension.ignoreFailures
     }
 }

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -136,8 +136,4 @@ class CucumberTask extends DefaultTask implements CucumberRunnerOptions {
     boolean getJunitReport() {
         return junitReport ?: extension.junitReport
     }
-
-    boolean getIgnoreFailures() {
-        return ignoreFailures ?: extension.ignoreFailures
-    }
 }


### PR DESCRIPTION
Logs the failure and report link rather than failing the Gradle build, so that Jenkins can mark the build as unstable when there are test failures. That's preferable to failing the build when you're running cucumber tests as part of a larger build.