### PR TITLE
Cleanup old results before running specs anew

### DIFF
--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
@@ -51,6 +51,9 @@ class CucumberRunner {
     }
 
     boolean run(SourceSet sourceSet, File resultsDir, File reportsDir) {
+        resultsDir.deleteDir()
+        resultsDir.mkdirs()
+
         AtomicBoolean hasFeatureParseErrors = new AtomicBoolean(false)
 
         def features = findFeatures(sourceSet)


### PR DESCRIPTION
Otherwise with continuous Gradle builds (with `-t` option) old results appear again and again after each run.

@JayStGelais 